### PR TITLE
Fix README anchor link collision

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 GitHub uses special files such as `README` and `LICENSE`, and special paths such as `/.github` and `/docs`, to improve repository managment and developer interactions.  This page is a summary. We welcome pull requests.
 
 * [Introduction](#introduction)
-* [README](#readme)
+* [README](#user-content-readme)
 * [CHANGELOG](#changelog)
 * [LICENSE](#license)
 * [SUPPORT](#support)


### PR DESCRIPTION
the link to `#readme` in TOC goes to the top of README file rather than the "readme" section, as the section name collides with an id already inserted into the page by Github. fixed by linking to a different anchor