### PR TITLE
docs: add reference to the-dot-github-repo-pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Although the documentation does not stipulate this as a general rule, files in `
 
 The special files and paths are sometimes also known as community health files, recommended repository files, well-known configurations, etc.
 
-For a general overview see [building a strong community](https://help.github.com/categories/building-a-strong-community/) and [GitHub's Open Source Guides](https://opensource.guide/).
+For a general overview see [building a strong community](https://help.github.com/categories/building-a-strong-community/) and [GitHub's Open Source Guides](https://opensource.guide/). For a playful exploration of some of the ways you can (mis)use these GitHub conventions, see [`the-dot-github-repo-pattern`](https://github.com/hesreallyhim/the-dot-github-repo-pattern).
 
 Starters:
 


### PR DESCRIPTION
Hi @joelparkerhenderson , I created a repo that demonstrates a pattern that I have actually used before for some of my "game" repos, wherein the entire repository source code is moved under `.github/`, mostly in order to achieve some aesthetic effect.

It's partly satirical, partly a demo of a pattern that I have occasionally used (despite clearly marking it as a "bad practice"), and I think it also has some educational value. I hope you'll consider including it here. thanks!

see https://github.com/hesreallyhim/the-dot-github-repo-pattern